### PR TITLE
Correct docs for WebPkiVerifier server impl

### DIFF
--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -283,7 +283,6 @@ impl ServerCertVerifier for WebPkiVerifier {
     /// - Signed by a  trusted `RootCertStore` CA
     /// - Not Expired
     /// - Valid for DNS entry
-    /// - OCSP data is present
     fn verify_server_cert(
         &self,
         end_entity: &Certificate,


### PR DESCRIPTION
The ServerCertVerifier impl docs were claiming that `verify_server_cert` would verify that OCSP data was present,
but the function's result as implemented does not depend on the `ocsp_response` field.

Fixes #885